### PR TITLE
[devops/ci] updating to latest rexpy

### DIFF
--- a/_setup.py
+++ b/_setup.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 import time
   
-rexpy_version = "0.1.18"
+rexpy_version = "0.1.20"
 
 def __intsall_regis():
   os.system(f"py -m pip uninstall --yes regis")

--- a/_setup.py
+++ b/_setup.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 import time
   
-rexpy_version = "0.1.21"
+rexpy_version = "0.1.23"
 
 def __intsall_regis():
   os.system(f"py -m pip uninstall --yes regis")

--- a/_setup.py
+++ b/_setup.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 import time
   
-rexpy_version = "0.1.23"
+rexpy_version = "0.1.24"
 
 def __intsall_regis():
   os.system(f"py -m pip uninstall --yes regis")

--- a/_test.py
+++ b/_test.py
@@ -18,6 +18,7 @@ if __name__ == "__main__":
   parser = argparse.ArgumentParser()
   parser.add_argument("-clean", help="clean run, as if run for the first time", action="store_true")
   parser.add_argument("-single_threaded", help="run tests in single threaded mode", action="store_true")
+  parser.add_argument("-filter_lines", help="filter lines to only display warnings and errors", action="store_true")
 
   parser.add_argument("-all", help="run all tests", action="store_true")
   parser.add_argument("-iwyu", help="run include-what-you-use", action="store_true")
@@ -36,7 +37,7 @@ if __name__ == "__main__":
   if args.all or args.iwyu:
     regis.test.test_include_what_you_use(args.clean, args.single_threaded)
   if args.all or args.clang_tidy:
-    regis.test.test_clang_tidy(".*", args.clean, args.single_threaded)
+    regis.test.test_clang_tidy(".*", args.clean, args.single_threaded, args.filter_lines)
   if args.all or args.unit_tests:
     regis.test.test_unit_tests(["rexstdtest"], args.clean, args.single_threaded)
   if args.all or args.coverage:

--- a/_test.py
+++ b/_test.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
   parser = argparse.ArgumentParser()
   parser.add_argument("-clean", help="clean run, as if run for the first time", action="store_true")
   parser.add_argument("-single_threaded", help="run tests in single threaded mode", action="store_true")
-  parser.add_argument("-filter_lines", help="filter lines to only display warnings and errors", action="store_true")
+  parser.add_argument("-only_errors_and_warnings", help="filter lines to only display warnings and errors", action="store_true")
 
   parser.add_argument("-all", help="run all tests", action="store_true")
   parser.add_argument("-iwyu", help="run include-what-you-use", action="store_true")

--- a/_test.py
+++ b/_test.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
   if args.all or args.iwyu:
     regis.test.test_include_what_you_use(args.clean, args.single_threaded)
   if args.all or args.clang_tidy:
-    regis.test.test_clang_tidy(".*", args.clean, args.single_threaded, args.filter_lines)
+    regis.test.test_clang_tidy(".*", args.clean, args.single_threaded, args.only_errors_and_warnings)
   if args.all or args.unit_tests:
     regis.test.test_unit_tests(["rexstdtest"], args.clean, args.single_threaded)
   if args.all or args.coverage:

--- a/source/post_build.py
+++ b/source/post_build.py
@@ -4,7 +4,7 @@ import argparse
 
 def run(projectName, compdb, srcroot, useClangTools, allChecks, clangTidyRegex):
   if (useClangTools):
-    regis.run_clang_tools.run(projectName, compdb, srcroot, allChecks, clangTidyRegex)
+    regis.run_clang_tools.run(projectName, compdb, srcroot, allChecks, clangTidyRegex, False)
 
   return
 


### PR DESCRIPTION
we can filter clang-tidy lines now to only display warnings and errors
we can also run clang-tidy incrementally