### PR TITLE
[devops/update_sharpmake] updating to latest version of sharpmake

### DIFF
--- a/_build/config/required_tools.json
+++ b/_build/config/required_tools.json
@@ -102,7 +102,7 @@
     "config_name": "sharpmake_path",
     "archive_name": "Sharpmake",
     "num_zip_files": 1,
-    "version" : "sharpmake-0.21.1-r0.7"  
+    "version" : "sharpmake-0.21.1-r0.8"  
   },
   "llvm_profdata" : 
   {


### PR DESCRIPTION
this has an update to ninja generation so we don't have data races anymore when running clang-tidy